### PR TITLE
feat(yourcandidates): add gray bg when hover on list on party list card 

### DIFF
--- a/apps/yourcandidates/components/candidateCard/PartyList.vue
+++ b/apps/yourcandidates/components/candidateCard/PartyList.vue
@@ -93,6 +93,11 @@ export default {
   border-bottom: 1px solid var(--color-gray-2);
   cursor: pointer;
 }
+
+.party-list-box:hover {
+  background-color: var(--color-gray-1);
+}
+
 .scrollbar::-webkit-scrollbar {
   width: 5px;
 }


### PR DESCRIPTION
เพิ่ม background สีเทา เมื่อทำการ hover ที่รายชื่อปาร์ตี้ลิสต์แต่ละคน 
<img width="517" alt="Screenshot 2566-04-14 at 16 31 22" src="https://user-images.githubusercontent.com/33986491/232007437-bcce9ef0-6d60-496e-8381-4783e6ae064d.png">
